### PR TITLE
Set limits to the versions we support.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     long_description_content_type='text/markdown',
     install_requires=[
                 'numpy',
-                'pandas',
+                'pandas<=0.25.3',
                 'sklearn',
                 'logging'
           ]


### PR DESCRIPTION
The goal of this pull request is to set supported version for ```numpy```, ```pandas```, ```skelarn```, and ```logging``` in **setup.py**. Users will benefit from this as they are not able to install this package unless they have the supported versions installed. Currently, for example, we have the issue that the ```pandas``` versions >= 1.0 has changed the API for the MultiIndex.