### PR TITLE
Meta Information

### DIFF
--- a/fasttrees/__init__.py
+++ b/fasttrees/__init__.py
@@ -1,1 +1,4 @@
+__description__ = "A fast and frugal tree classifier for sklearn"
 __version__ = "1.2.2"
+__author__ = "Dominic Zijlstra"
+__author_email__ = "dominiczijlstra@gmail.com"

--- a/fasttrees/__init__.py
+++ b/fasttrees/__init__.py
@@ -1,4 +1,6 @@
 __description__ = "A fast and frugal tree classifier for sklearn"
-__version__ = "1.2.2"
 __author__ = "Dominic Zijlstra"
+
+__license__ = "MIT"
+__version__ = "1.2.2"
 __author_email__ = "dominiczijlstra@gmail.com"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 from setuptools import setup
 
 
+import fasttrees
+
+
 def get_long_description():
     ''' returns the content of the README.md file as a string.
     '''
@@ -28,9 +31,9 @@ setup(
     packages=['fasttrees'],
     url='https://github.com/dominiczy/fasttrees',
     license='MIT License',
-    author='dominiczijlstra',
-    author_email='dominiczijlstra@gmail.com',
-    description='A fast and frugal tree classifier for sklearn',
+    author=fasttrees.__author__,
+    author_email=fasttrees.__author_email__,
+    description=fasttrees.__description__,
     long_description=get_long_description(),
     long_description_content_type='text/markdown',
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -15,19 +15,10 @@ def get_long_description():
     return long_description
 
 
-def get_version():
-    ''' returns the version number given in __init__.py as a string.
-    '''
-    import re
-
-    with open("fasttrees/__init__.py", mode='r', encoding="utf-8") as f:
-        version = re.search(r'__version__ = "(.*?)"', f.read()).group(1)
-    return version
-
 
 setup(
     name='fasttrees',
-    version=get_version(),
+    version=fasttrees.__version__,
     packages=['fasttrees'],
     url='https://github.com/dominiczy/fasttrees',
     license='MIT License',


### PR DESCRIPTION
The goal of this pull reqeust is to add a minimum of meta information into ```__init__.py```. In that process, function ```get_version()``` ([this function was added here](https://github.com/dominiczy/fasttrees/pull/1/commits/b264b106eeb877af5156d2ff11fc0fcc914ef231)) was removed as the version number can be easily set by importing the package.