### PR TITLE
Set sklearn version

### DIFF
--- a/fasttrees/__init__.py
+++ b/fasttrees/__init__.py
@@ -1,6 +1,6 @@
 __description__ = "A fast and frugal tree classifier for sklearn"
-__author__ = "Dominic Zijlstra"
+__author__ = "Dominic Zijlstra, Stefan Bachhofner"
 
 __license__ = "MIT"
 __version__ = "1.2.2"
-__author_email__ = "dominiczijlstra@gmail.com"
+__author_email__ = "dominiczijlstra@gmail.com, bachhofner.dev@gmail.com"

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     install_requires=[
                 'numpy',
                 'pandas<=0.25.3',
-                'sklearn',
+                'sklearn<=0.23.2',
                 'logging'
           ]
 )


### PR DESCRIPTION
This pull request sets the upper sklearn version that can be used with the code. The restriction has to be set because after sklearn 0.23.2, the API for scorer has moved. This resolves dominiczy/fasttrees#4.