### PR TITLE
Add quick start and badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Downloads](https://static.pepy.tech/badge/fasttrees)](https://pepy.tech/project/fasttrees)
 ![PyPI - Version](https://img.shields.io/pypi/v/fasttrees)
-
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/fasttrees)
 
 # fasttrees
 A fast-and-frugal-tree classifier based on Python's scikit learn.

--- a/README.md
+++ b/README.md
@@ -25,13 +25,15 @@ from sklearn import datasets, model_selection
 from fasttrees.fasttrees import FastFrugalTreeClassifier
 
 
+# Load data set
 iris_dict = datasets.load_iris(as_frame=True)
 
+# Split into train and test data set
 X_iris, y_iris = iris_dict['data'], iris_dict['target']
-
 X_train_iris, y_train_iris, X_test_iris, y_test_iris = model_selection.train_test_split(
     X_iris, y_iris, test_size=0.4, random_state=42)
 
+# Fit and test fitted tree
 fftc = FastFrugalTreeClassifier()
 fftc.fit(X_train_iris, y_train_iris)
 fftc.score(X_test_iris, y_test_iris)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,28 @@ You can install fasttrees using
 pip install fasttrees
 ```
 
+## Quick first start
+
+Below we provide a qick first start example with fast-and-frugal trees. We use the popular [iris flower data set (also known as the Fisher's Iris data set)](https://doi.org/10.1111/j.1469-1809.1936.tb02137.x), split it into a train and test data set, and fit a fast-and-frugal tree classifier on the training data set. Finally, we get the score on the test data set.
+
+```python
+from sklearn import datasets, model_selection
+
+from fasttrees.fasttrees import FastFrugalTreeClassifier
+
+
+iris_dict = datasets.load_iris(as_frame=True)
+
+X_iris, y_iris = iris_dict['data'], iris_dict['target']
+
+X_train_iris, y_train_iris, X_test_iris, y_test_iris = model_selection.train_test_split(X_iris, y_iris, test_size=0.4, random_state=42)
+
+fftc = FastFrugalTreeClassifier()
+fftc.fit(X_train_iris, y_train_iris)
+
+fftc.score(X_test_iris, y_test_iris)
+```
+
 ## Usage
 Instantiate a fast-and-frugal tree classifier:
 ```python

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Downloads](https://static.pepy.tech/badge/fasttrees)](https://pepy.tech/project/fasttrees)
+[https://img.shields.io/pypi/v/fasttrees](https://img.shields.io/pypi/v/fasttrees)
 
 # fasttrees
 A fast-and-frugal-tree classifier based on Python's scikit learn.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Downloads](https://static.pepy.tech/badge/fasttrees)](https://pepy.tech/project/fasttrees)
+
 # fasttrees
 A fast-and-frugal-tree classifier based on Python's scikit learn.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Downloads](https://static.pepy.tech/badge/fasttrees)](https://pepy.tech/project/fasttrees)
-
 ![PyPI - Version](https://img.shields.io/pypi/v/fasttrees)
 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Downloads](https://static.pepy.tech/badge/fasttrees)](https://pepy.tech/project/fasttrees)
-[https://img.shields.io/pypi/v/fasttrees](https://img.shields.io/pypi/v/fasttrees)
+
+![PyPI - Version](https://img.shields.io/pypi/v/fasttrees)
+
 
 # fasttrees
 A fast-and-frugal-tree classifier based on Python's scikit learn.

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ iris_dict = datasets.load_iris(as_frame=True)
 
 X_iris, y_iris = iris_dict['data'], iris_dict['target']
 
-X_train_iris, y_train_iris, X_test_iris, y_test_iris = model_selection.train_test_split(X_iris, y_iris, test_size=0.4, random_state=42)
+X_train_iris, y_train_iris, X_test_iris, y_test_iris = model_selection.train_test_split(
+    X_iris, y_iris, test_size=0.4, random_state=42)
 
 fftc = FastFrugalTreeClassifier()
 fftc.fit(X_train_iris, y_train_iris)
-
 fftc.score(X_test_iris, y_test_iris)
 ```
 


### PR DESCRIPTION
Add a quick start section that uses the iris data set to the README file. In addition, add three badges that pull statistics about downloads from pepy, and two badges for displaying current library version available on PyPi and supported Python versions according to PyPi.